### PR TITLE
fix: remove duplicate ci jobs

### DIFF
--- a/.github/workflows/terraform.yaml
+++ b/.github/workflows/terraform.yaml
@@ -5,6 +5,8 @@ name: Check Terraform Modules
 
 on:
   push:
+    branches:
+      - main
   pull_request:
     branches:
       - main


### PR DESCRIPTION
# Description

This change makes the CI trigger only on PR events, and not on push. This will prevent duplicate runs of CI jobs.

# Checklist:

- [ ] My code follows the [style guidelines](/CONTRIBUTING.md) of this project
- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that validate the behaviour of the software
- [ ] I validated that new and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [ ] I have bumped the version of the library