### PR TITLE
fix: set grafana agent channel to 1/stable

### DIFF
--- a/modules/oai-ran-cu-k8s/variables.tf
+++ b/modules/oai-ran-cu-k8s/variables.tf
@@ -29,7 +29,7 @@ variable "cu_config" {
 variable "grafana_agent_channel" {
   description = "The channel to use when deploying `grafana-agent-k8s` charm."
   type        = string
-  default     = "latest/stable"
+  default     = "1/stable"
 }
 variable "grafana_agent_config" {
   description = "Additional configuration for the Grafana Agent. Details about available options can be found at https://charmhub.io/grafana-agent-k8s/configure."

--- a/modules/oai-ran-du-k8s/variables.tf
+++ b/modules/oai-ran-du-k8s/variables.tf
@@ -29,7 +29,7 @@ variable "du_config" {
 variable "grafana_agent_channel" {
   description = "The channel to use when deploying `grafana-agent-k8s` charm."
   type        = string
-  default     = "latest/stable"
+  default     = "1/stable"
 }
 variable "grafana_agent_config" {
   description = "Additional configuration for the Grafana Agent. Details about available options can be found at https://charmhub.io/grafana-agent-k8s/configure."

--- a/modules/oai-ran-k8s/variables.tf
+++ b/modules/oai-ran-k8s/variables.tf
@@ -40,7 +40,7 @@ variable "du_config" {
 variable "grafana_agent_channel" {
   description = "The channel to use when deploying `grafana-agent-k8s` charm."
   type        = string
-  default     = "latest/stable"
+  default     = "1/stable"
 }
 variable "grafana_agent_config" {
   description = "Additional configuration for the Grafana Agent. Details about available options can be found at https://charmhub.io/grafana-agent-k8s/configure."


### PR DESCRIPTION
# Description

Grafana agent charm has been released to `1/stable`. This PR updates the channel

# Checklist:

- [ ] My code follows the [style guidelines](/CONTRIBUTING.md) of this project
- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that validate the behaviour of the software
- [ ] I validated that new and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [ ] I have bumped the version of the library